### PR TITLE
try adding GA tracking to landing page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,6 +18,7 @@ minima:
     twitter: pysal_devs
     github:  gdsbook
     rss: rss
+    google_analytics: UA-146598819-1
     # dribbble: jekyll
     # facebook: jekyll
     # flickr:   jekyll


### PR DESCRIPTION
I think this is where the `google_analytics` ID has to go, according to the [jekyll documentation](https://github.com/jekyll/minima#enabling-google-analytics)? 